### PR TITLE
Preferred workshops

### DIFF
--- a/backend/app/components/user/user.controller.js
+++ b/backend/app/components/user/user.controller.js
@@ -57,12 +57,7 @@ exports.signInHandler = (req, resp) => {
 
 };
 
-
-exports.getLikedHandler = async (req, resp) => {
-  // TODO-code-challenge: Bonus: As a User, I can display the list of preferred workshops
-  // See userService.getLikedWorkshops
-  resp.status(200).json([]);
-};
+//Removed getliked handler as I handled this in the workshops controller with getPreferred
 
 exports.addToLikedHandler = async (req, resp) => {
   let idWorkshop = req.params.id;
@@ -83,11 +78,34 @@ exports.addToLikedHandler = async (req, resp) => {
 
 
 exports.removeFromLikedHandler = async (req, resp) => {
-  // TODO-code-challenge: Bonus: As a User, I can remove a workshop from my preferred workshops list
-  resp.status(200).json();
+  let idWorkshop = req.params.id;
+  let idUser = req.token.id;
+  winston.debug(`Removing workshop ${idWorkshop} to Liked list of user ${idUser}`);
+
+  let workshop = await workshopService.getById(idWorkshop);
+  if (workshop === false || workshop === null) {
+    resp.status(500).json();
+  }
+  if (await userService.unlikeWorkshop(idUser, workshop) ) {
+    resp.status(200).json();
+  } else {
+    resp.status(500).json();
+  }  resp.status(200).json();
 };
 
 exports.addToDislikedHandler = async (req, resp) => {
-  // TODO-code-challenge: Bonus: As a User, I can dislike a workshop, so it won’t be displayed within “Nearby WorkShops” list during the next 2 hours
+  let idWorkshop = req.params.id;
+  let idUser = req.token.id;
+  winston.debug(`Adding workshop ${idWorkshop} to disliked list of user ${idUser}`);
+
+  let workshop = await workshopService.getById(idWorkshop);
+  if (workshop === false || workshop === null) {
+    resp.status(500).json();
+  }
+  if (await userService.dislikeWorkshop(idUser, workshop) ) {
+    resp.status(200).json();
+  } else {
+    resp.status(500).json();
+  }  resp.status(200).json();
   resp.status(200).json();
 };

--- a/backend/app/components/user/user.router.js
+++ b/backend/app/components/user/user.router.js
@@ -8,8 +8,6 @@ module.exports = (auth) => {
   router.post('/sign-up', userController.signUpHandler);
   router.post('/sign-in', userController.signInHandler);
 
-  router.get('/workshops/liked', auth, userController.getLikedHandler);
-
   router.post('/workshops/liked/:id', auth, userController.addToLikedHandler);
   router.delete('/workshops/liked/:id', auth, userController.removeFromLikedHandler);
   router.post('/workshops/disliked/:id', auth, userController.addToDislikedHandler);

--- a/backend/app/components/user/user.service.js
+++ b/backend/app/components/user/user.service.js
@@ -52,7 +52,15 @@ exports.getDislikedWorkshops = async (id) => {
 };
 
 exports.likeWorkshop = async (idUser, workshop) => {
-  // TODO-code-challenge: Secondary Functionality: As a User, I can like a workshop, so it can be added to my preferred workshops
+  try {
+    let user = await User.findById(idUser);
+    user.likedWorkshops.push({workshopId:workshop._id});
+    await user.save();
+    return true;
+  } catch (err) {
+    winston.error(`User Service: updating liked workshops for user ${idUser}` );
+    return false;
+  }
 };
 
 exports.unlikeWorkshop = async (idUser, workshop) => {
@@ -79,4 +87,13 @@ exports.unlikeWorkshop = async (idUser, workshop) => {
 
 exports.dislikeWorkshop = async (idUser, workshop) => {
   // TODO-code-challenge: Bonus: As a User, I can dislike a workshop, so it won’t be displayed within “Nearby WorkShops” list during the next 2 hours
+  try {
+    let user = await User.findById(idUser);
+    user.dislikedWorkshops.push({workshopId:workshop._id});
+    await user.save();
+    return true;
+  } catch (err) {
+    winston.error(`User Service: updating disliked workshops for user ${idUser}` );
+    return false;
+  }
 };

--- a/backend/app/components/workshop/workshop.controller.js
+++ b/backend/app/components/workshop/workshop.controller.js
@@ -14,3 +14,13 @@ exports.getNearby = async (req, resp) => {
     resp.status(200).json(workshops);
   }
 };
+
+exports.getPreferred = async (req, resp) => {
+  winston.debug(`Getting preferred workshops for user ${req.token.id}`);
+  let workshops = await workshopService.getPreferred(req.token.id);
+  if (workshops === false) {
+    resp.status(500).json();
+  } else {
+    resp.status(200).json(workshops);
+  }
+};

--- a/backend/app/components/workshop/workshop.model.js
+++ b/backend/app/components/workshop/workshop.model.js
@@ -13,6 +13,12 @@ const WorkshopSchema = new Schema({
     coordinates: [Number]
   }
 });
+WorkshopSchema.set('toObject', { virtuals: true })
+WorkshopSchema.set('toJSON', { virtuals: true })
+
+WorkshopSchema.virtual('preferred')
+.get(function() { return this._preferred; })
+.set(function(pref) { this._preferred = pref; });
 
 const Workshop = mongoose.model('Workshop', WorkshopSchema);
 

--- a/backend/app/components/workshop/workshop.router.js
+++ b/backend/app/components/workshop/workshop.router.js
@@ -6,5 +6,7 @@ const workshopController = require ('./workshop.controller');
 
 module.exports = (auth) => {
   router.get('/nearby', auth, workshopController.getNearby);
+  router.get('/preferred', auth, workshopController.getPreferred);
+
   return router;
 };

--- a/backend/app/components/workshop/workshop.service.js
+++ b/backend/app/components/workshop/workshop.service.js
@@ -52,8 +52,13 @@ exports.getNearby = async (id, longitude, latitude) => {
         if (workshops[i]._id.toString() === sp.workshopId.toString()) {
           if (sp.likedTime) {
             // TODO-code-challenge: Secondary Functionality: As a User, I can like a workshop, so it can be added to my preferred workshops
+            workshops.splice(i, 1);
           } else if (sp.dislikedTime) {
             // TODO-code-challenge: Bonus: As a User, I can dislike a workshop, so it won’t be displayed within “Nearby WorkShops” list during the next 2 hours
+            let hours = moment().diff(moment(sp.dislikedTime), 'hours');
+            if( hours < 2){
+              workshops.splice(i, 1);
+            }
           }
         }
       }

--- a/backend/app/components/workshop/workshop.service.js
+++ b/backend/app/components/workshop/workshop.service.js
@@ -8,7 +8,6 @@ const userService = require('../user/user.service');
 
 const Workshop = require('./workshop.model');
 
-
 exports.getById = async (id) => {
   try {
     winston.debug(`Workshop service getting by id ${id}`);
@@ -70,3 +69,27 @@ exports.getNearby = async (id, longitude, latitude) => {
     return false;
   }
 };
+
+exports.getPreferred = async (id) => {
+  try {
+  workshops = await Workshop.find();
+  let likedWorkshops = await userService.getLikedWorkshops(id);
+  respWorkshops = [];
+  for (let i = 0 ; i < workshops.length ; i++) {
+    for (let li of likedWorkshops) {
+      if (workshops[i]._id.toString() === li.workshopId.toString()) {
+        if (li.likedTime) {
+          //Setting a virtual value for preferred to change front end like button
+          workshops[i].set('preferred', true);
+          respWorkshops.push(workshops[i]);
+        }
+      }
+    }
+  }
+     return respWorkshops;
+  } catch (err) {
+    winston.error(`Workshop Service: Error getting preferred workshops`);
+    winston.debug(err);
+    return false;
+  }
+}

--- a/frontend/src/components/WorkshopDisplay/WorkshopDisplay.js
+++ b/frontend/src/components/WorkshopDisplay/WorkshopDisplay.js
@@ -103,7 +103,8 @@ class WorkshopDisplay extends Component {
       }
 
     } else if (mode === '/workshops/preferred') {
-      // TODO-code-challenge: Bonus: As a User, I can display the list of preferred workshops
+      url = `http://localhost:3000/api/v1/workshops/preferred`;
+      this.fetchWorkshops(url);
     } else {
       this.props.history.push('/workshops/nearby');
     }

--- a/frontend/src/components/WorkshopItem/WorkshopItem.js
+++ b/frontend/src/components/WorkshopItem/WorkshopItem.js
@@ -3,7 +3,12 @@ import React, { Component } from 'react';
 import './WorkshopItem.css';
 
 class WorkshopItem extends Component {
-
+  constructor(props) {
+    super(props);
+    this.state = {
+      showWorkshop: true,
+    };
+  }
   componentWillUnmount () {
     console.log('Unmounting workshop item ');
   }
@@ -14,8 +19,8 @@ class WorkshopItem extends Component {
       fetch (`http://localhost:3000/api/v1/users/workshops/liked/${this.props._id}`, { headers: {Authorization: `Bearer ${localStorage.getItem('token')}`}, method: 'POST' })
       .then ( (resp) => {
         if (resp.status === 200) {
-          console.log ('Workshop Item added to preferred workshops !');
-          this.props.selfUnmount(this.props._id);
+          console.log (`Workshop ${this.props._id} added to preferred workshops !`);
+          this.setState({showWorkshop:false});
         }
         else {
           console.log(`Status returned ${resp.status}`); }
@@ -35,25 +40,29 @@ class WorkshopItem extends Component {
   }
 
   render() {
-    return (
-      <article className="workshop-item">
-          <div className="up">
-            <h2 className="title">{this.props.name}</h2>
-          </div>
-          <div className="middle">
-            <img className="workshop-img" src={this.props.picture} alt="" />
-          </div>
-          <div className="down">
-            <div className={this.props.preferred ? "hidden": ""}>
-              <button className="workshop-btn dislike-btn" onClick={this.dislikeClickHandler.bind(this)}>Dislike</button>
-              <button className="workshop-btn like-btn" onClick={this.likeClickHandler.bind(this)}>Like</button>
+    if(this.state.showWorkshop){
+      return (
+        <article className="workshop-item">
+            <div className="up">
+              <h2 className="title">{this.props.name}</h2>
             </div>
-            <div className={this.props.preferred ? "": "hidden"}>
-              <button className="workshop-btn remove-btn" onClick={this.removeClickHandler.bind(this)}>Remove</button>
+            <div className="middle">
+              <img className="workshop-img" src={this.props.picture} alt="" />
             </div>
-          </div>
-      </article>
-    );
+            <div className="down">
+              <div className={this.props.preferred ? "hidden": ""}>
+                <button className="workshop-btn dislike-btn" onClick={this.dislikeClickHandler.bind(this)}>Dislike</button>
+                <button className="workshop-btn like-btn" onClick={this.likeClickHandler.bind(this)}>Like</button>
+              </div>
+              <div className={this.props.preferred ? "": "hidden"}>
+                <button className="workshop-btn remove-btn" onClick={this.removeClickHandler.bind(this)}>Remove</button>
+              </div>
+            </div>
+        </article>
+      );
+    } else {
+      return null;
+    }
   }
 }
 

--- a/frontend/src/components/WorkshopItem/WorkshopItem.js
+++ b/frontend/src/components/WorkshopItem/WorkshopItem.js
@@ -14,7 +14,6 @@ class WorkshopItem extends Component {
   }
 
   likeClickHandler (ev) {
-    console.log('like');
     if (!this.props.preferred) {
       fetch (`http://localhost:3000/api/v1/users/workshops/liked/${this.props._id}`, { headers: {Authorization: `Bearer ${localStorage.getItem('token')}`}, method: 'POST' })
       .then ( (resp) => {
@@ -32,11 +31,35 @@ class WorkshopItem extends Component {
   }
 
   dislikeClickHandler (ev) {
-    // TODO-code-challenge: Bonus: As a User, I can dislike a workshop, so it won’t be displayed within “Nearby WorkShops” list during the next 2 hours
+    fetch (`http://localhost:3000/api/v1/users/workshops/disliked/${this.props._id}`, { headers: {Authorization: `Bearer ${localStorage.getItem('token')}`}, method: 'POST' })
+    .then ( (resp) => {
+      if (resp.status === 200) {
+        console.log (`Workshop ${this.props._id} added to user's disliked workshops !`);
+        this.setState({showWorkshop:false});
+      }
+      else {
+        console.log(`Status returned ${resp.status}`); }
+      } )
+    .catch( (err) => {
+      console.error(err);
+    } );
   }
 
   removeClickHandler (ev) {
-    // TODO-code-challenge: Bonus: As a User, I can remove a workshop from my preferred workshops list
+    if (this.props.preferred) {
+      fetch (`http://localhost:3000/api/v1/users/workshops/liked/${this.props._id}`, { headers: {Authorization: `Bearer ${localStorage.getItem('token')}`}, method: 'DELETE' })
+      .then ( (resp) => {
+        if (resp.status === 200) {
+          console.log (`Workshop ${this.props._id} removed from preferred workshops !`);
+          this.setState({showWorkshop:false});
+        }
+        else {
+          console.log(`Status returned ${resp.status}`); }
+        } )
+      .catch( (err) => {
+        console.error(err);
+      } );
+    }
   }
 
   render() {


### PR DESCRIPTION
Normally I would have separated this into 3 PRs.

One for preferred workshop functionality, one for handling dislikes and a final for removing liked. 

However, I did end up going over the requested time limit so I decided to include the work that went over into its own PR. 

Functionality added:

- Updated the like and dislike functionality in the userServices.

- Updated the like, remove from like and dislike functionality in the user controller.

- Created a showWorkshop state value to remove workshops from the list on like/dislike instead of resending the query for the new list. 

- Added a route for preferred to the Workshop controller. I later noticed that there was one set up in the user controller, but I decided to remove it as I again was already a little over time at this point. 

- Added a virtual for preferred to the WorkshopSchema, this way we could add the preferred variable onto the object on return without modifying the DB.

- Added functionality on the front end to remove likes when a user is on the preferred list

- Added functionality on the front end to dislike a workshop.

**Notes:**
If I had more time I would have liked to use 'Liked' more consistently on the backend, I did switch to preferred and I think that makes the code slightly confusing.